### PR TITLE
add: 完善元素的解析

### DIFF
--- a/pkg/message/message_element.go
+++ b/pkg/message/message_element.go
@@ -1,5 +1,9 @@
 package message
 
+import (
+	"golang.org/x/net/html"
+)
+
 type MessageElement interface {
 	Tag() string
 	Stringify() string
@@ -31,9 +35,54 @@ func (e *ChildrenMessageElement) stringifyChildren() string {
 	return result
 }
 
-func (e *ChildrenMessageElement) stringifyByTag(tag string) string {
-	if e == nil || len(e.Children) == 0 {
-		return "<" + tag + " />"
+func (e *ChildrenMessageElement) parseChildren(n *html.Node) (*ChildrenMessageElement, error) {
+	var children []MessageElement
+	err := parseHtmlChildrenNode(n, func(e MessageElement) {
+		children = append(children, e)
+	})
+	if err != nil {
+		return nil, err
 	}
-	return "<" + tag + ">" + e.stringifyChildren() + "</" + tag + ">"
+	result := &ChildrenMessageElement{
+		Children: children,
+	}
+	return result, nil
+}
+
+type ExtendAttributes struct {
+	Attributes map[string]string
+}
+
+func (e *ExtendAttributes) AddAttribute(key, value string) *ExtendAttributes {
+	result := e
+	if result == nil {
+		result = &ExtendAttributes{
+			Attributes: make(map[string]string),
+		}
+	}
+	result.Attributes[key] = value
+	return result
+}
+
+func (e *ExtendAttributes) Get(key string) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	v, ok := e.Attributes[key]
+	return v, ok
+}
+
+func (e *ExtendAttributes) stringifyAttributes() string {
+	if e == nil || len(e.Attributes) == 0 {
+		return ""
+	}
+	var result string
+	for k, v := range e.Attributes {
+		if v == "" {
+			result += " " + k
+		} else {
+			result += " " + k + `="` + escape(v, true) + `"`
+		}
+	}
+	return result
 }

--- a/pkg/message/message_element_basic.go
+++ b/pkg/message/message_element_basic.go
@@ -16,7 +16,7 @@ func (e *MessageElementText) Tag() string {
 }
 
 func (e *MessageElementText) Stringify() string {
-	return e.Content
+	return escape(e.Content, true)
 }
 
 func (e *MessageElementText) Parse(n *html.Node) (MessageElement, error) {
@@ -46,18 +46,18 @@ func (e *MessageElementAt) Tag() string {
 func (e *MessageElementAt) Stringify() string {
 	result := "<" + e.Tag()
 	if e.Id != "" {
-		result += ` id="` + e.Id + `"`
+		result += ` id="` + escape(e.Id, true) + `"`
 	}
 	if e.Name != "" {
-		result += ` name="` + e.Name + `"`
+		result += ` name="` + escape(e.Name, true) + `"`
 	}
 	if e.Role != "" {
-		result += ` role="` + e.Role + `"`
+		result += ` role="` + escape(e.Role, true) + `"`
 	}
 	if e.Type != "" {
-		result += ` type="` + e.Type + `"`
+		result += ` type="` + escape(e.Type, true) + `"`
 	}
-	return result + " />"
+	return result + "/>"
 }
 
 func (e *MessageElementAt) Parse(n *html.Node) (MessageElement, error) {
@@ -83,12 +83,12 @@ func (e *MessageElementSharp) Tag() string {
 func (e *MessageElementSharp) Stringify() string {
 	result := "<" + e.Tag()
 	if e.Id != "" {
-		result += ` id="` + e.Id + `"`
+		result += ` id="` + escape(e.Id, true) + `"`
 	}
 	if e.Name != "" {
-		result += ` name="` + e.Name + `"`
+		result += ` name="` + escape(e.Name, true) + `"`
 	}
-	return result + " />"
+	return result + "/>"
 }
 
 func (e *MessageElementSharp) Parse(n *html.Node) (MessageElement, error) {
@@ -111,9 +111,9 @@ func (e *MessageElementA) Tag() string {
 func (e *MessageElementA) Stringify() string {
 	result := "<" + e.Tag()
 	if e.Href != "" {
-		result += ` href="` + e.Href + `"`
+		result += ` href="` + escape(e.Href, true) + `"`
 	}
-	return result + " />"
+	return result + "/>"
 }
 func (e *MessageElementA) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)

--- a/pkg/message/message_element_basic.go
+++ b/pkg/message/message_element_basic.go
@@ -33,6 +33,8 @@ func (e *MessageElementText) Parse(n *html.Node) (MessageElement, error) {
 
 type MessageElementAt struct {
 	*noAliasMessageElement
+	*ChildrenMessageElement
+	*ExtendAttributes
 	Id   string
 	Name string //	收发	目标用户的名称
 	Role string //	收发	目标角色
@@ -44,7 +46,7 @@ func (e *MessageElementAt) Tag() string {
 }
 
 func (e *MessageElementAt) Stringify() string {
-	result := "<" + e.Tag()
+	result := ""
 	if e.Id != "" {
 		result += ` id="` + escape(e.Id, true) + `"`
 	}
@@ -57,21 +59,39 @@ func (e *MessageElementAt) Stringify() string {
 	if e.Type != "" {
 		result += ` type="` + escape(e.Type, true) + `"`
 	}
-	return result + "/>"
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementAt) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
-	return &MessageElementAt{
+	result := &MessageElementAt{
 		Id:   attrMap["id"],
 		Name: attrMap["name"],
 		Role: attrMap["role"],
 		Type: attrMap["type"],
-	}, nil
+	}
+	for key, value := range attrMap {
+		if key != "id" && key != "name" && key != "role" && key != "type" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementSharp struct {
 	*noAliasMessageElement
+	*ChildrenMessageElement
+	*ExtendAttributes
 	Id   string //收发	目标频道的 ID
 	Name string //收发	目标频道的名称
 }
@@ -81,26 +101,44 @@ func (e *MessageElementSharp) Tag() string {
 }
 
 func (e *MessageElementSharp) Stringify() string {
-	result := "<" + e.Tag()
+	result := ""
 	if e.Id != "" {
 		result += ` id="` + escape(e.Id, true) + `"`
 	}
 	if e.Name != "" {
 		result += ` name="` + escape(e.Name, true) + `"`
 	}
-	return result + "/>"
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementSharp) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
-	return &MessageElementSharp{
+	result := &MessageElementSharp{
 		Id:   attrMap["id"],
 		Name: attrMap["name"],
-	}, nil
+	}
+	for key, value := range attrMap {
+		if key != "id" && key != "name" && key != "role" && key != "type" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementA struct {
 	*noAliasMessageElement
+	*ChildrenMessageElement
+	*ExtendAttributes
 	Href string
 }
 
@@ -109,17 +147,33 @@ func (e *MessageElementA) Tag() string {
 }
 
 func (e *MessageElementA) Stringify() string {
-	result := "<" + e.Tag()
+	result := ""
 	if e.Href != "" {
 		result += ` href="` + escape(e.Href, true) + `"`
 	}
-	return result + "/>"
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 func (e *MessageElementA) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
-	return &MessageElementA{
+	result := &MessageElementA{
 		Href: attrMap["href"],
-	}, nil
+	}
+	for key, value := range attrMap {
+		if key != "href" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 func init() {

--- a/pkg/message/message_element_decorative.go
+++ b/pkg/message/message_element_decorative.go
@@ -6,6 +6,7 @@ import (
 
 type MessageElementStrong struct {
 	*ChildrenMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementStrong) Tag() string {
@@ -16,26 +17,31 @@ func (e *MessageElementStrong) Alias() []string {
 }
 
 func (e *MessageElementStrong) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementStrong) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementStrong{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementStrong{
-		&ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementEm struct {
 	*ChildrenMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementEm) Tag() string {
@@ -46,26 +52,31 @@ func (e *MessageElementEm) Alias() []string {
 }
 
 func (e *MessageElementEm) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementEm) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementEm{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementEm{
-		&ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementIns struct {
 	*ChildrenMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementIns) Tag() string {
@@ -77,26 +88,31 @@ func (e *MessageElementIns) Alias() []string {
 }
 
 func (e *MessageElementIns) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementIns) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementIns{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementIns{
-		&ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementDel struct {
 	*ChildrenMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementDel) Tag() string {
@@ -108,27 +124,32 @@ func (e *MessageElementDel) Alias() []string {
 }
 
 func (e *MessageElementDel) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementDel) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementDel{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementDel{
-		ChildrenMessageElement: &ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementSpl struct {
 	*noAliasMessageElement
 	*ChildrenMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementSpl) Tag() string {
@@ -136,27 +157,32 @@ func (e *MessageElementSpl) Tag() string {
 }
 
 func (e *MessageElementSpl) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementSpl) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementSpl{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementSpl{
-		ChildrenMessageElement: &ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementCode struct {
 	*ChildrenMessageElement
 	*noAliasMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementCode) Tag() string {
@@ -164,27 +190,32 @@ func (e *MessageElementCode) Tag() string {
 }
 
 func (e *MessageElementCode) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementCode) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementCode{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementCode{
-		ChildrenMessageElement: &ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementSup struct {
 	*ChildrenMessageElement
 	*noAliasMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementSup) Tag() string {
@@ -192,27 +223,32 @@ func (e *MessageElementSup) Tag() string {
 }
 
 func (e *MessageElementSup) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementSup) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementSup{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementSup{
-		ChildrenMessageElement: &ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 type MessageElementSub struct {
 	*ChildrenMessageElement
 	*noAliasMessageElement
+	*ExtendAttributes
 }
 
 func (e *MessageElementSub) Tag() string {
@@ -220,22 +256,26 @@ func (e *MessageElementSub) Tag() string {
 }
 
 func (e *MessageElementSub) Stringify() string {
-	return e.stringifyByTag(e.Tag())
+	result := e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementSub) Parse(n *html.Node) (MessageElement, error) {
-	var children []MessageElement
-	err := parseHtmlChildrenNode(n, func(e MessageElement) {
-		children = append(children, e)
-	})
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementSub{}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
 	if err != nil {
 		return nil, err
 	}
-	return &MessageElementSub{
-		ChildrenMessageElement: &ChildrenMessageElement{
-			Children: children,
-		},
-	}, nil
+	result.ChildrenMessageElement = children
+	return result, nil
 }
 
 func init() {

--- a/pkg/message/message_element_extend.go
+++ b/pkg/message/message_element_extend.go
@@ -1,0 +1,42 @@
+package message
+
+import "golang.org/x/net/html"
+
+type MessageElementExtend struct {
+	*noAliasMessageElement
+	*ChildrenMessageElement
+	*ExtendAttributes
+	Type string
+}
+
+func (e *MessageElementExtend) Tag() string {
+	return e.Type
+}
+
+func (e *MessageElementExtend) Stringify() string {
+	result := ""
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
+}
+
+func (e *MessageElementExtend) Parse(n *html.Node) (MessageElement, error) {
+	attrMap := attrList2MapVal(n.Attr)
+	result := &MessageElementExtend{
+		Type: n.Data,
+	}
+	for key, value := range attrMap {
+		result.ExtendAttributes = result.AddAttribute(key, value)
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
+	return result, nil
+}
+
+var ExtendParser = &MessageElementExtend{}

--- a/pkg/message/message_element_meta.go
+++ b/pkg/message/message_element_meta.go
@@ -45,20 +45,20 @@ func (e *MessageElementAuthor) Tag() string {
 func (e *MessageElementAuthor) Stringify() string {
 	result := "<" + e.Tag()
 	if e.Id != "" {
-		result += ` id="` + e.Id + `"`
+		result += ` id="` + escape(e.Id, true) + `"`
 	}
 	if e.Name != "" {
-		result += ` name="` + e.Name + `"`
+		result += ` name="` + escape(e.Name, true) + `"`
 	}
 	if e.Avatar != "" {
-		result += ` avatar="` + e.Avatar + `"`
+		result += ` avatar="` + escape(e.Avatar, true) + `"`
 	}
 	// result += ">"
 	childrenStr := e.stringifyChildren()
 	if childrenStr == "" {
-		return result + ` />`
+		return result + `/>`
 	}
-	return result + ` >` + childrenStr + `</` + e.Tag() + `>`
+	return result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementAuthor) Parse(n *html.Node) (MessageElement, error) {

--- a/pkg/message/message_element_oprator.go
+++ b/pkg/message/message_element_oprator.go
@@ -24,21 +24,21 @@ func (e *MessageElementButton) Tag() string {
 func (e *MessageElementButton) Stringify() string {
 	result := "<" + e.Tag()
 	if e.Id != "" {
-		result += ` id="` + e.Id + `"`
+		result += ` id="` + escape(e.Id, true) + `"`
 	}
 	if e.Type != "" {
-		result += ` type="` + e.Type + `"`
+		result += ` type="` + escape(e.Type, true) + `"`
 	}
 	if e.Href != "" {
-		result += ` href="` + e.Href + `"`
+		result += ` href="` + escape(e.Href, true) + `"`
 	}
 	if e.Text != "" {
-		result += ` text="` + e.Text + `"`
+		result += ` text="` + escape(e.Text, true) + `"`
 	}
 	if e.Theme != "" {
-		result += ` theme="` + e.Theme + `"`
+		result += ` theme="` + escape(e.Theme, true) + `"`
 	}
-	return result + " />"
+	return result + "/>"
 }
 
 func (e *MessageElementButton) Parse(n *html.Node) (MessageElement, error) {

--- a/pkg/message/message_element_resource.go
+++ b/pkg/message/message_element_resource.go
@@ -44,12 +44,15 @@ import (
 // }
 
 // func (e *ResourceRootMessageElement) stringifyByTag(tag string) string {
-// 	return "<" + tag + e.attrString() + " />"
+// 	return "<" + tag + e.attrString() + "/>"
 // }
 
 type MessageElementImg struct {
 	*noAliasMessageElement
+	*ChildrenMessageElement
+	*ExtendAttributes
 	Src     string
+	Title   string
 	Cache   bool
 	Timeout string //ms
 	Width   uint32
@@ -68,6 +71,9 @@ func (e *MessageElementImg) attrString() string {
 	if e.Src != "" {
 		result += ` src="` + escape(e.Src, true) + `"`
 	}
+	if e.Title != "" {
+		result += ` title="` + escape(e.Title, true) + `"`
+	}
 	if e.Cache {
 		result += ` cache`
 	}
@@ -78,22 +84,28 @@ func (e *MessageElementImg) attrString() string {
 }
 
 func (e *MessageElementImg) Stringify() string {
-	result := "<" + e.Tag()
+	result := ""
 	attrStr := e.attrString()
 	if e.Width > 0 {
-		attrStr += fmt.Sprintf(" width=%d", e.Width)
+		attrStr += fmt.Sprintf(` width="%d"`, e.Width)
 	}
 	if e.Height > 0 {
-		attrStr += fmt.Sprintf(" height=%d", e.Height)
+		attrStr += fmt.Sprintf(` height="%d"`, e.Height)
 	}
 	result += attrStr
-	return result + " />"
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementImg) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
 	result := &MessageElementImg{
 		Src:     attrMap["src"],
+		Title:   attrMap["title"],
 		Cache:   false,
 		Timeout: attrMap["timeout"],
 	}
@@ -115,14 +127,29 @@ func (e *MessageElementImg) Parse(n *html.Node) (MessageElement, error) {
 		}
 		result.Height = uint32(height)
 	}
+	for key, value := range attrMap {
+		if key != "src" && key != "title" && key != "cache" && key != "timeout" && key != "width" && key != "height" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
 	return result, nil
 }
 
 type MessageElementAudio struct {
 	*noAliasMessageElement
-	Src     string
-	Cache   bool
-	Timeout string //ms
+	*ChildrenMessageElement
+	*ExtendAttributes
+	Src      string
+	Title    string
+	Cache    bool
+	Timeout  string //ms
+	Duration uint32
+	Poster   string
 }
 
 func (e *MessageElementAudio) Tag() string {
@@ -137,6 +164,9 @@ func (e *MessageElementAudio) attrString() string {
 	if e.Src != "" {
 		result += ` src="` + escape(e.Src, true) + `"`
 	}
+	if e.Title != "" {
+		result += ` title="` + escape(e.Title, true) + `"`
+	}
 	if e.Cache {
 		result += ` cache`
 	}
@@ -147,15 +177,29 @@ func (e *MessageElementAudio) attrString() string {
 }
 
 func (e *MessageElementAudio) Stringify() string {
-	result := "<" + e.Tag()
-	result += e.attrString()
-	return result + " />"
+	result := ""
+	attrStr := e.attrString()
+	if e.Duration > 0 {
+		attrStr += fmt.Sprintf(` duration="%d"`, e.Duration)
+
+	}
+	if e.Poster != "" {
+		attrStr += ` poster="` + escape(e.Poster, true) + `"`
+	}
+	result += attrStr
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementAudio) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
 	result := &MessageElementAudio{
 		Src:     attrMap["src"],
+		Title:   attrMap["title"],
 		Cache:   false,
 		Timeout: attrMap["timeout"],
 	}
@@ -163,14 +207,41 @@ func (e *MessageElementAudio) Parse(n *html.Node) (MessageElement, error) {
 	if ok {
 		result.Cache = cacheAttr == "" || cacheAttr == "true" || cacheAttr == "1"
 	}
+	if d, ok := attrMap["duration"]; ok {
+		duration, e := strconv.Atoi(d)
+		if e != nil {
+			return nil, fmt.Errorf("duration[%s] is illegal:%v", d, e)
+		}
+		result.Duration = uint32(duration)
+	}
+	if p, ok := attrMap["poster"]; ok {
+		result.Poster = p
+	}
+	for key, value := range attrMap {
+		if key != "src" && key != "title" && key != "cache" && key != "timeout" && key != "duration" && key != "poster" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
 	return result, nil
 }
 
 type MessageElementVideo struct {
 	*noAliasMessageElement
-	Src     string
-	Cache   bool
-	Timeout string //ms
+	*ChildrenMessageElement
+	*ExtendAttributes
+	Src      string
+	Title    string
+	Cache    bool
+	Timeout  string //ms
+	Width    uint32
+	Height   uint32
+	Duration uint32
+	Poster   string
 }
 
 func (e *MessageElementVideo) Tag() string {
@@ -185,6 +256,9 @@ func (e *MessageElementVideo) attrString() string {
 	if e.Src != "" {
 		result += ` src="` + escape(e.Src, true) + `"`
 	}
+	if e.Title != "" {
+		result += ` title="` + escape(e.Title, true) + `"`
+	}
 	if e.Cache {
 		result += ` cache`
 	}
@@ -195,15 +269,34 @@ func (e *MessageElementVideo) attrString() string {
 }
 
 func (e *MessageElementVideo) Stringify() string {
-	result := "<" + e.Tag()
-	result += e.attrString()
-	return result + " />"
+	result := ""
+	attrStr := e.attrString()
+	if e.Width > 0 {
+		attrStr += fmt.Sprintf(` width="%d"`, e.Width)
+	}
+	if e.Height > 0 {
+		attrStr += fmt.Sprintf(` height="%d"`, e.Height)
+	}
+	if e.Duration > 0 {
+		attrStr += fmt.Sprintf(` duration="%d"`, e.Duration)
+	}
+	if e.Poster != "" {
+		attrStr += ` poster="` + escape(e.Poster, true) + `"`
+	}
+	result += attrStr
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementVideo) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
 	result := &MessageElementVideo{
 		Src:     attrMap["src"],
+		Title:   attrMap["title"],
 		Cache:   false,
 		Timeout: attrMap["timeout"],
 	}
@@ -211,14 +304,52 @@ func (e *MessageElementVideo) Parse(n *html.Node) (MessageElement, error) {
 	if ok {
 		result.Cache = cacheAttr == "" || cacheAttr == "true" || cacheAttr == "1"
 	}
+	if w, ok := attrMap["width"]; ok {
+		width, e := strconv.Atoi(w)
+		if e != nil {
+			return nil, fmt.Errorf("width[%s] is illegal:%v", w, e)
+		}
+		result.Width = uint32(width)
+	}
+	if h, ok := attrMap["height"]; ok {
+		height, e := strconv.Atoi(h)
+		if e != nil {
+			return nil, fmt.Errorf("height[%s] is illegal:%v", h, e)
+		}
+		result.Height = uint32(height)
+	}
+	if d, ok := attrMap["duration"]; ok {
+		duration, e := strconv.Atoi(d)
+		if e != nil {
+			return nil, fmt.Errorf("duration[%s] is illegal:%v", d, e)
+		}
+		result.Duration = uint32(duration)
+	}
+	if p, ok := attrMap["poster"]; ok {
+		result.Poster = p
+	}
+	for key, value := range attrMap {
+		if key != "src" && key != "title" && key != "cache" && key != "timeout" && key != "width" && key != "height" && key != "duration" && key != "poster" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
 	return result, nil
 }
 
 type MessageElementFile struct {
 	*noAliasMessageElement
+	*ChildrenMessageElement
+	*ExtendAttributes
 	Src     string
+	Title   string
 	Cache   bool
 	Timeout string //ms
+	Poster  string
 }
 
 func (e *MessageElementFile) Tag() string {
@@ -232,6 +363,9 @@ func (e *MessageElementFile) attrString() string {
 	if e.Src != "" {
 		result += ` src="` + escape(e.Src, true) + `"`
 	}
+	if e.Title != "" {
+		result += ` title="` + escape(e.Title, true) + `"`
+	}
 	if e.Cache {
 		result += ` cache`
 	}
@@ -241,15 +375,25 @@ func (e *MessageElementFile) attrString() string {
 	return result
 }
 func (e *MessageElementFile) Stringify() string {
-	result := "<" + e.Tag()
-	result += e.attrString()
-	return result + " />"
+	result := ""
+	attrStr := e.attrString()
+	if e.Poster != "" {
+		attrStr += ` poster="` + escape(e.Poster, true) + `"`
+	}
+	result += attrStr
+	result += e.stringifyAttributes()
+	childrenStr := e.stringifyChildren()
+	if childrenStr == "" {
+		return `<` + e.Tag() + result + `/>`
+	}
+	return `<` + e.Tag() + result + `>` + childrenStr + `</` + e.Tag() + `>`
 }
 
 func (e *MessageElementFile) Parse(n *html.Node) (MessageElement, error) {
 	attrMap := attrList2MapVal(n.Attr)
 	result := &MessageElementFile{
 		Src:     attrMap["src"],
+		Title:   attrMap["title"],
 		Cache:   false,
 		Timeout: attrMap["timeout"],
 	}
@@ -257,6 +401,19 @@ func (e *MessageElementFile) Parse(n *html.Node) (MessageElement, error) {
 	if ok {
 		result.Cache = cacheAttr == "" || cacheAttr == "true" || cacheAttr == "1"
 	}
+	if p, ok := attrMap["poster"]; ok {
+		result.Poster = p
+	}
+	for key, value := range attrMap {
+		if key != "src" && key != "title" && key != "cache" && key != "timeout" && key != "poster" {
+			result.ExtendAttributes = result.AddAttribute(key, value)
+		}
+	}
+	children, err := result.parseChildren(n)
+	if err != nil {
+		return nil, err
+	}
+	result.ChildrenMessageElement = children
 	return result, nil
 }
 

--- a/pkg/message/message_element_resource.go
+++ b/pkg/message/message_element_resource.go
@@ -66,7 +66,7 @@ func (e *MessageElementImg) attrString() string {
 	}
 	result := ""
 	if e.Src != "" {
-		result += ` src="` + e.Src + `"`
+		result += ` src="` + escape(e.Src, true) + `"`
 	}
 	if e.Cache {
 		result += ` cache`
@@ -135,7 +135,7 @@ func (e *MessageElementAudio) attrString() string {
 	}
 	result := ""
 	if e.Src != "" {
-		result += ` src="` + e.Src + `"`
+		result += ` src="` + escape(e.Src, true) + `"`
 	}
 	if e.Cache {
 		result += ` cache`
@@ -183,7 +183,7 @@ func (e *MessageElementVideo) attrString() string {
 	}
 	result := ""
 	if e.Src != "" {
-		result += ` src="` + e.Src + `"`
+		result += ` src="` + escape(e.Src, true) + `"`
 	}
 	if e.Cache {
 		result += ` cache`
@@ -230,7 +230,7 @@ func (e *MessageElementFile) attrString() string {
 	}
 	result := ""
 	if e.Src != "" {
-		result += ` src="` + e.Src + `"`
+		result += ` src="` + escape(e.Src, true) + `"`
 	}
 	if e.Cache {
 		result += ` cache`

--- a/pkg/message/message_element_typography.go
+++ b/pkg/message/message_element_typography.go
@@ -62,7 +62,7 @@ func (e *MessageElementMessage) Tag() string {
 func (e *MessageElementMessage) Stringify() string {
 	result := ""
 	if e.Id != "" {
-		result += ` id="` + e.Id + `"`
+		result += ` id="` + escape(e.Id, true) + `"`
 	}
 	if e.Forward {
 		result += ` forward`

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -1,7 +1,6 @@
 package message
 
 import (
-	"fmt"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -41,7 +40,6 @@ var factory = &parsersStruct{
 }
 
 func RegsiterParserElement(parser MessageElementParser) {
-	fmt.Printf("set parser tag:[%s],with alias: %v\n", parser.Tag(), parser.Alias())
 	factory.set(parser.Tag(), parser.Parse)
 	if len(parser.Alias()) > 0 {
 		for _, tag := range parser.Alias() {

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -60,6 +60,13 @@ func parseHtmlNode(n *html.Node, callback func(e MessageElement)) error {
 				return err
 			}
 			callback(e)
+		} else {
+			e, err := ExtendParser.Parse(n)
+			if err != nil {
+				return err
+			}
+			callback(e)
+			parsed = true
 		}
 	} else if n.Type == html.TextNode {
 		content := strings.TrimSpace(n.Data)

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -1,7 +1,6 @@
 package message
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -89,7 +88,7 @@ func parseHtmlChildrenNode(n *html.Node, callback func(e MessageElement)) error 
 }
 
 func Parse(source string) ([]MessageElement, error) {
-	doc, _ := html.Parse(bytes.NewReader([]byte(source)))
+	doc := xhtmlParse(source)
 	var result []MessageElement
 	err := parseHtmlNode(doc, func(e MessageElement) {
 		if e != nil {

--- a/pkg/message/parser_test.go
+++ b/pkg/message/parser_test.go
@@ -8,20 +8,16 @@ func Test(t *testing.T) {
 	for group, messages := range _getRawMessage() {
 		t.Logf("start test group: %s", group)
 		for _, message := range messages {
-			_, err := Parse(message.Raw)
+			elements, err := Parse(message)
 			if err != nil {
-				t.Fatalf("%s Parse error: %s", message.Raw, err)
+				t.Fatalf("%s Parse error: %s", message, err)
 			}
-			result, err := Stringify(message.Elements)
+			result, err := Stringify(elements)
 			if err != nil {
-				t.Fatalf("%s Stringify error: %s", message.Elements, err)
+				t.Fatalf("%s Stringify error: %s", elements, err)
 			}
-			if message.TargetRaw != "" {
-				if result != message.TargetRaw {
-					t.Fatalf("%s not eq %s", result, message.TargetRaw)
-				}
-			} else if result != message.Raw {
-				t.Fatalf("%s not eq %s", result, message.Raw)
+			if result != message {
+				t.Fatalf("%s not eq %s", result, message)
 			}
 		}
 	}

--- a/pkg/message/parser_test_data.go
+++ b/pkg/message/parser_test_data.go
@@ -1,569 +1,72 @@
 package message
 
-type rawToElement struct {
-	Raw       string
-	TargetRaw string
-	Elements  []MessageElement
-}
-
-func _getRawMessage() map[string][]rawToElement {
-	raw_message := make(map[string][]rawToElement)
-	raw_message["Basic"] = _getBasicRawMessage()
-	raw_message["Layout"] = _getLayoutRawMessage()
-	raw_message["Meta"] = _getMetaRawMessage()
-	raw_message["Resource"] = _getResourceRawMessage()
-	raw_message["Modifier"] = _getModifierRawMessage()
-	raw_message["Examples"] = _getExamplesRawMessage()
+func _getRawMessage() map[string][]string {
+	raw_message := make(map[string][]string)
+	raw_message["basic"] = _getBasicRawMessage()
+	raw_message["resource"] = _getResourceRawMessage()
+	raw_message["decorate"] = _getDecorateRawMessage()
+	raw_message["layout"] = _getLayoutRawMessage()
+	raw_message["meta"] = _getMetaRawMessage()
+	raw_message["interact"] = _getInteractRawMessage()
+	raw_message["extend"] = _getExtendRawMessage()
 	return raw_message
 }
 
-func _getExamplesRawMessage() []rawToElement {
-	return []rawToElement{
+func _getBasicRawMessage() []string {
+	return []string{
 		// Single message
-		{
-			Raw: `
-				<message>
-				<at id="1" name="test" />
-				<at id="2" name="test2" />
-				<br/>
-				<p>test</p>
-				<img src="https://example.com" />
-				<audio src="https://example.com" />
-				<p>
-					<b>bold</b>
-					<sup>sup</sup>
-					<sub>sub</sub>
-					<spl>spoiler</spl>
-					<code>code</code>
-					<u>underline</u>
-					<s>strikethrough</s>
-				</p>
-				</message>`,
-			TargetRaw: `<message><at id="1" name="test" /><at id="2" name="test2" /><br/><p>test</p><img src="https://example.com" /><audio src="https://example.com" /><p><b>bold</b><sup>sup</sup><sub>sub</sub><spl>spoiler</spl><code>code</code><u>underline</u><s>strikethrough</s></p></message>`,
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					ChildrenMessageElement: &ChildrenMessageElement{
-						Children: []MessageElement{
-							&MessageElementAt{
-								Id:   "1",
-								Name: "test",
-							},
-							&MessageElementAt{
-								Id:   "2",
-								Name: "test2",
-							},
-							&MessageElmentBr{},
-							&MessageElmentP{
-								ChildrenMessageElement: &ChildrenMessageElement{
-									Children: []MessageElement{
-										&MessageElementText{
-											Content: "test",
-										},
-									},
-								},
-							},
-							&MessageElementImg{
-								Src: "https://example.com",
-							},
-							&MessageElementAudio{
-								Src: "https://example.com",
-							},
-							&MessageElmentP{
-								ChildrenMessageElement: &ChildrenMessageElement{
-									/**
-									<b>bold</b>
-									<sup>sup</sup>
-									<sub>sub</sub>
-									<spl>spoiler</spl>
-									<code>code</code>
-									<u>underline</u>
-									<s>strikethrough</s>
-									*/
-									Children: []MessageElement{
-										&MessageElementStrong{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "bold",
-													},
-												},
-											},
-										},
-										&MessageElementSup{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "sup",
-													},
-												},
-											},
-										},
-										&MessageElementSub{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "sub",
-													},
-												},
-											},
-										},
-										&MessageElementSpl{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "spoiler",
-													},
-												},
-											},
-										},
-										&MessageElementCode{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "code",
-													},
-												},
-											},
-										},
-										&MessageElementIns{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "underline",
-													},
-												},
-											},
-										},
-										&MessageElementDel{
-											ChildrenMessageElement: &ChildrenMessageElement{
-												Children: []MessageElement{
-													&MessageElementText{
-														Content: "strikethrough",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{Raw: `<message>
-<code>
-  yarn add nitori
-  yarn run test
-  npm publish
-</code>
-</message>`,
-			TargetRaw: "<message><code>yarn add nitori\n  yarn run test\n  npm publish</code></message>",
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					ChildrenMessageElement: &ChildrenMessageElement{
-						Children: []MessageElement{
-							&MessageElementCode{
-								ChildrenMessageElement: &ChildrenMessageElement{
-									Children: []MessageElement{
-										&MessageElementText{
-											Content: "yarn add nitori\n  yarn run test\n  npm publish",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+		`I can eat glass and it doesn't hurt me.`,
+		`<at id="test" name="test" role="test" type="test"/>`,
+		`<sharp id="test" name="test"/>`,
+		`<a href="https://example.com"/>`,
 	}
 }
 
-func _getModifierRawMessage() []rawToElement {
-	return []rawToElement{
-		{
-			Raw:       `<strong>test</strong>`,
-			TargetRaw: `<b>test</b>`,
-			Elements: []MessageElement{&MessageElementStrong{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<b>test</b>`,
-			Elements: []MessageElement{&MessageElementStrong{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw:       `<em>test</em>`,
-			TargetRaw: `<i>test</i>`,
-			Elements: []MessageElement{&MessageElementEm{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<i>test</i>`,
-			Elements: []MessageElement{&MessageElementEm{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw:       `<ins>test</ins>`,
-			TargetRaw: `<u>test</u>`,
-			Elements: []MessageElement{&MessageElementIns{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<u>test</u>`,
-			Elements: []MessageElement{&MessageElementIns{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw:       `<del>test</del>`,
-			TargetRaw: `<s>test</s>`,
-			Elements: []MessageElement{&MessageElementDel{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<s>test</s>`,
-			Elements: []MessageElement{&MessageElementDel{
-				&ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<spl>test</spl>`,
-			Elements: []MessageElement{&MessageElementSpl{
-				ChildrenMessageElement: &ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<code>test</code>`,
-			Elements: []MessageElement{&MessageElementCode{
-				ChildrenMessageElement: &ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<sup>test</sup>`,
-			Elements: []MessageElement{&MessageElementSup{
-				ChildrenMessageElement: &ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
-		{
-			Raw: `<sub>test</sub>`,
-			Elements: []MessageElement{&MessageElementSub{
-				ChildrenMessageElement: &ChildrenMessageElement{
-					Children: []MessageElement{&MessageElementText{
-						Content: "test",
-					}},
-				},
-			}},
-		},
+func _getResourceRawMessage() []string {
+	return []string{
+		`<img src="https://example.com" title="exampleImage" cache timeout="1145141919" width="200" height="200"/>`,
+		`<audio src="https://example.com" title="exampleAudio" cache timeout="1145141919" duration="114514" poster="https://example.com"/>`,
+		`<video src="https://example.com" title="exampleVideo" cache timeout="1145141919" width="200" height="200" duration="114514" poster="https://example.com"/>`,
+		`<file src="https://example.com" title="exampleFile" cache timeout="1145141919" poster="https://example.com"/>`,
 	}
 }
 
-func _getResourceRawMessage() []rawToElement {
-	return []rawToElement{
-		{
-			Raw: `<img src="https://example.com" />`,
-			Elements: []MessageElement{
-				&MessageElementImg{
-					Src: "https://example.com",
-				},
-			},
-		},
-		{
-			Raw: `<img src="https://example.com" cache timeout="1000" />`,
-			Elements: []MessageElement{
-				&MessageElementImg{
-					Src:     "https://example.com",
-					Cache:   true,
-					Timeout: "1000",
-				}},
-		},
-		{
-			Raw:       `<img src="https://example.com" width="300" height="200" />`,
-			TargetRaw: `<img src="https://example.com" width=300 height=200 />`,
-			Elements: []MessageElement{&MessageElementImg{
-				Src:    "https://example.com",
-				Width:  300,
-				Height: 200,
-			}},
-		},
-		{
-			Raw: `<audio src="https://example.com" />`,
-			Elements: []MessageElement{&MessageElementAudio{
-				Src: "https://example.com",
-			}},
-		},
-		{
-			Raw: `<video src="https://example.com" />`,
-			Elements: []MessageElement{&MessageElementVideo{
-				Src: "https://example.com",
-			}},
-		},
-		{
-			Raw: `<file src="https://example.com" />`,
-			Elements: []MessageElement{&MessageElementFile{
-				Src: "https://example.com",
-			}},
-		},
+func _getDecorateRawMessage() []string {
+	return []string{
+		`<b>b<i>italic</i>o<u>under<s>deleteline</s>line</u>l<spl>sp<code>code</code>oi<sup>s<sub>sub</sub>up</sup>ler</spl>d</b>`,
+		`<code>for key, value range attributes {
+			fmt.Println(key, value)
+		}</code>`,
 	}
 }
 
-func _getMetaRawMessage() []rawToElement {
-	return []rawToElement{
-		{
-			Raw:      `<quote />`,
-			Elements: []MessageElement{&MessageElementQuote{}},
-		},
-		{
-			Raw: `<quote>test</quote>`,
-			Elements: []MessageElement{&MessageElementQuote{
-				ChildrenMessageElement: &ChildrenMessageElement{
-					Children: []MessageElement{
-						&MessageElementText{
-							Content: "test",
-						},
-					},
-				},
-			}},
-		},
-		{
-			Raw:      `<author />`,
-			Elements: []MessageElement{&MessageElementAuthor{}},
-		},
-		{
-			Raw: `<author id="1" />`,
-			Elements: []MessageElement{&MessageElementAuthor{
-				Id: "1",
-			}},
-		},
-		{
-			Raw: `<author id="1" name="test" />`,
-			Elements: []MessageElement{&MessageElementAuthor{
-				Id:   "1",
-				Name: "test",
-			}},
-		},
+func _getLayoutRawMessage() []string {
+	return []string{
+		`<br/>`,
+		`<p>test</p>`,
+		`<message id="test" forward><p>test</p>test<br/><p>test<br/></p></message>`,
+		`test<message/>test`,
 	}
 }
 
-func _getLayoutRawMessage() []rawToElement {
-	return []rawToElement{
-		{
-			Raw: "<br/>",
-			Elements: []MessageElement{
-				&MessageElmentBr{},
-			},
-		},
-		{
-			Raw: `<p>test</p>`,
-			Elements: []MessageElement{
-				&MessageElmentP{
-					ChildrenMessageElement: &ChildrenMessageElement{
-						Children: []MessageElement{
-							&MessageElementText{
-								Content: "test",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			Raw: `<p>testtest2</p>`,
-			Elements: []MessageElement{
-				&MessageElmentP{
-					ChildrenMessageElement: &ChildrenMessageElement{
-						Children: []MessageElement{
-							&MessageElementText{
-								Content: "testtest2",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			Raw: `<p>test<br/></p>`,
-			Elements: []MessageElement{
-				&MessageElmentP{
-					ChildrenMessageElement: &ChildrenMessageElement{
-						Children: []MessageElement{
-							&MessageElementText{
-								Content: "test",
-							},
-							&MessageElmentBr{},
-						},
-					},
-				},
-			},
-		},
-		{
-			Raw: `<message />`,
-			Elements: []MessageElement{
-				&MessageElementMessage{},
-			},
-		},
-		{
-			Raw: `<message id="1" />`,
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					Id: "1",
-				},
-			},
-		},
-		{
-			Raw: `<message forward />`,
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					Forward: true,
-				},
-			},
-		},
-		{
-			Raw: `<message id="1" forward />`,
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					Id:      "1",
-					Forward: true,
-				},
-			},
-		},
-		{
-			Raw:       `<message id="1" forward="false" />`,
-			TargetRaw: `<message id="1" />`,
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					Id:      "1",
-					Forward: false,
-				},
-			},
-		},
-		{
-			Raw: `<message>test</message>`,
-			Elements: []MessageElement{
-				&MessageElementMessage{
-					ChildrenMessageElement: &ChildrenMessageElement{
-						Children: []MessageElement{
-							&MessageElementText{
-								Content: "test",
-							},
-						},
-					},
-				},
-			},
-		},
+func _getMetaRawMessage() []string {
+	return []string{
+		`<quote><author id="test" name="test">test</author>test</quote>`,
+		`<author id="test" name="test" avatar="https://example.com"/>`,
 	}
 }
 
-func _getBasicRawMessage() []rawToElement {
-	return []rawToElement{
-		{
-			Raw: "纯文本",
-			Elements: []MessageElement{
-				&MessageElementText{
-					Content: "纯文本",
-				},
-			},
-		},
-		{
-			Raw: `<at id="1" name="test" />`,
-			Elements: []MessageElement{
-				&MessageElementAt{
-					Id:   "1",
-					Name: "test",
-				},
-			},
-		},
-		{
-			Raw: `<at role="test" />`,
-			Elements: []MessageElement{
-				&MessageElementAt{
-					Role: "test",
-				},
-			},
-		},
-		{
-			Raw: `<at type="test" />`,
-			Elements: []MessageElement{
-				&MessageElementAt{
-					Type: "test",
-				},
-			},
-		},
-		{
-			Raw: `<sharp id="1" />`,
-			Elements: []MessageElement{
-				&MessageElementSharp{
-					Id: "1",
-				},
-			},
-		},
-		{
-			Raw: `<sharp id="1" name="test" />`,
-			Elements: []MessageElement{
-				&MessageElementSharp{
-					Id:   "1",
-					Name: "test",
-				},
-			},
-		},
-		{
-			Raw: `<a href="https://example.com" />`,
-			Elements: []MessageElement{
-				&MessageElementA{
-					Href: "https://example.com",
-				},
-			},
-		},
+func _getInteractRawMessage() []string {
+	return []string{
+		`<button id="test" type="test" href="https://example.com" text="test" theme="test"/>`,
+	}
+}
+
+func _getExtendRawMessage() []string {
+	return []string{
+		`<audio src="https://example.com" test:test="test"/>`,
+		`<video src="https://example.com" test:test/>`,
+		`<img src="https://example.com">test</img>`,
+		`<file src="https://example.com" test2:test2>test</file>`,
 	}
 }

--- a/pkg/message/parser_test_data.go
+++ b/pkg/message/parser_test_data.go
@@ -68,5 +68,6 @@ func _getExtendRawMessage() []string {
 		`<video src="https://example.com" test:test/>`,
 		`<img src="https://example.com">test</img>`,
 		`<file src="https://example.com" test2:test2>test</file>`,
+		`<test:test test="test">test</test:test>`,
 	}
 }

--- a/pkg/message/xhtml.go
+++ b/pkg/message/xhtml.go
@@ -1,0 +1,225 @@
+package message
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+var (
+	tagPat  = regexp.MustCompile(`(<!--[\s\S]*?-->)|(<(/?)([^!\s>/]*)([^>]*?)\s*(/?)>)`)
+	attrPat = regexp.MustCompile(`([^\s=]+)(?:="([^"]*)"|='([^']*)')?`)
+)
+
+func escape(text string, inLine bool) string {
+	text = strings.Replace(text, "&", "&amp;", -1)
+	text = strings.Replace(text, "<", "&lt;", -1)
+	text = strings.Replace(text, ">", "&gt;", -1)
+	if inLine {
+		text = strings.Replace(text, "\"", "&quot;", -1)
+	}
+	return text
+}
+
+func unescape(text string) string {
+	text = strings.Replace(text, "&lt;", "<", -1)
+	text = strings.Replace(text, "&gt;", ">", -1)
+	text = strings.Replace(text, "&quot;", "\"", -1)
+
+	re := regexp.MustCompile(`&#(\d+);`)
+	text = re.ReplaceAllStringFunc(text, func(s string) string {
+		matches := re.FindStringSubmatch(s)
+		if matches[1] == "38" {
+			return s
+		}
+		i, _ := strconv.Atoi(matches[1])
+		return fmt.Sprint(i)
+	})
+
+	re = regexp.MustCompile("&#x([0-9a-f]+);")
+	text = re.ReplaceAllStringFunc(text, func(s string) string {
+		matches := re.FindStringSubmatch(s)
+		if matches[1] == "26" {
+			return s
+		}
+		i, _ := strconv.ParseInt(matches[1], 16, 32)
+		return fmt.Sprint(i)
+	})
+
+	re = regexp.MustCompile("&(amp|#38|#x26);")
+	text = re.ReplaceAllString(text, "&")
+
+	return text
+}
+
+type Token struct {
+	*html.Token
+	extra string
+}
+
+func (t *Token) parseAttributes() []html.Attribute {
+	if t.extra == "" {
+		return nil
+	}
+	t.Attr = []html.Attribute{}
+	for {
+		attrLoc := attrPat.FindStringSubmatchIndex(t.extra)
+		if attrLoc == nil {
+			break
+		}
+
+		matches := attrPat.FindStringSubmatch(t.extra)
+		t.extra = t.extra[attrLoc[1]:]
+
+		key := matches[1]
+		var value string
+		if matches[2] != "" {
+			value = matches[2]
+		} else {
+			value = matches[3]
+		}
+		if value != "" {
+			t.Attr = append(t.Attr, html.Attribute{
+				Key: key,
+				Val: unescape(value),
+			})
+		} else if strings.HasPrefix(key, "no-") {
+			t.Attr = append(t.Attr, html.Attribute{
+				Key: key[3:],
+				Val: "false",
+			})
+		} else {
+			t.Attr = append(t.Attr, html.Attribute{
+				Key: key,
+				Val: "true",
+			})
+		}
+	}
+	return t.Attr
+}
+
+func parseTokens(tokens []Token) *html.Node {
+	var stack = []*html.Node{}
+	var root *html.Node = &html.Node{
+		Type: html.DocumentNode,
+		Data: "body",
+	}
+	stack = append(stack, root)
+
+	for _, token := range tokens {
+		switch token.Type {
+		case html.TextToken:
+			if len(stack) > 0 {
+				node := &html.Node{
+					Type: html.TextNode,
+					Data: token.Data,
+				}
+				stack[len(stack)-1].AppendChild(node)
+			}
+		case html.StartTagToken:
+			node := &html.Node{
+				Type: html.ElementNode,
+				Data: token.Data,
+				Attr: token.parseAttributes(),
+			}
+			if len(stack) > 0 {
+				stack[len(stack)-1].AppendChild(node)
+			} else {
+				root = node
+			}
+			stack = append(stack, node)
+		case html.EndTagToken:
+			if token.Data == stack[len(stack)-1].Data {
+				stack = stack[:len(stack)-1]
+			}
+		case html.SelfClosingTagToken:
+			node := &html.Node{
+				Type: html.ElementNode,
+				Data: token.Data,
+				Attr: token.parseAttributes(),
+			}
+			if len(stack) > 0 {
+				stack[len(stack)-1].AppendChild(node)
+			} else {
+				root = node
+			}
+		}
+	}
+	return root
+}
+
+func xhtmlParse(source string) *html.Node {
+	var tokens = []Token{}
+
+	var pushText = func(text string) {
+		if text != "" {
+			tokens = append(tokens, Token{
+				Token: &html.Token{
+					Type: html.TextToken,
+					Data: text,
+				},
+			})
+		}
+	}
+
+	var parseContent = func(source string, start, end bool) {
+		source = unescape(source)
+		if start {
+			re := regexp.MustCompile(`^\s*\n\s*`)
+			source = re.ReplaceAllString(source, "")
+		}
+		if end {
+			re := regexp.MustCompile(`\s*\n\s*$`)
+			source = re.ReplaceAllString(source, "")
+		}
+		pushText(source)
+	}
+
+	for {
+		tagLoc := tagPat.FindStringSubmatchIndex(source)
+		if tagLoc == nil {
+			break
+		}
+
+		parseContent(source[:tagLoc[0]], true, true)
+		matches := tagPat.FindStringSubmatch(source)
+		source = source[tagLoc[1]:]
+		close, type_, extra, empty := matches[3], matches[4], matches[5], matches[6]
+		if matches[1] != "" { // comment
+			continue
+		}
+		var token Token
+		if close == "" && empty == "" { // 开始标记
+			token = Token{
+				Token: &html.Token{
+					Type: html.StartTagToken,
+					Data: type_,
+				},
+				extra: extra,
+			}
+		} else if close != "" { // 结束标记
+			token = Token{
+				Token: &html.Token{
+					Type: html.EndTagToken,
+					Data: type_,
+				},
+				extra: extra,
+			}
+		} else if empty != "" { // 自闭合标记
+			token = Token{
+				Token: &html.Token{
+					Type: html.SelfClosingTagToken,
+					Data: type_,
+				},
+				extra: extra,
+			}
+		}
+		tokens = append(tokens, token)
+	}
+
+	parseContent(source, true, true)
+	return parseTokens(tokens)
+}

--- a/pkg/message/xhtml.go
+++ b/pkg/message/xhtml.go
@@ -94,7 +94,7 @@ func (t *Token) parseAttributes() []html.Attribute {
 		} else {
 			t.Attr = append(t.Attr, html.Attribute{
 				Key: key,
-				Val: "true",
+				Val: "",
 			})
 		}
 	}


### PR DESCRIPTION
添加并使用了对 XHTML 元素进行自定义解析的方法，并将其引入了现有的解析体系。
添加并完善了对目前已知所有消息元素扩展的支持，包括扩展元素、标准元素的扩展属性，以及所有元素（除文本元素外）的子元素支持。
修改并一定程度上统一了现有部分元素的字符串化方式与表现。